### PR TITLE
bugfix when using a Map with reducers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ module.exports = function (reducers) {
 
     return (state = Map({}), action) =>
       reducers.keySeq().reduce((nextstate, key) =>
-        nextstate.set(key, reducers.get(key)((state.get(key), action)))
+        nextstate.set(key, reducers.get(key)(state.get(key), action))
       , state);
   }
 


### PR DESCRIPTION
The extra pair of `()` makes the reducer function only being called with the action parameter and not the current state of the reducer